### PR TITLE
color-wallpaper speedup

### DIFF
--- a/bin/bin/color-wallpaper
+++ b/bin/bin/color-wallpaper
@@ -31,9 +31,8 @@ color() {
   echo "$colors" | awk '/*.?color'"$1"':/{print $2}'
 }
 
-# returns a formatted string to draw the specified circle
-circle() {
-  echo "$pos" | xargs -n3 | sed -n "$1"p | awk '{print "translate "$1", "$2"circle 0,0 "$3",0"}'
+voronoi_point() {
+  echo "$pos" | xargs -n2 | sed -n "$1"p | awk '{print "$1,$2}'
 }
 
 case "$1" in
@@ -75,11 +74,11 @@ fi
 pos=$(bc <<_EOF
   width=$(echo "$size" | cut -f1 -dx)
   height=$(echo "$size" | cut -f2 -dx)
-  scale=4; -40;           -40; width * 0.50; # top left
-  width * 0.75; height * 0.30; width * 0.30; # top right
-  width * 0.10; height * 0.70; width * 0.22; # bottom left
-  width * 0.50; height * 0.90; width * 0.15; # bottom middle
-  width * 0.80; height * 0.70; width * 0.20; # bottom right
+  scale=4; width * 0.30; height * 0.30; # top left
+  width * 0.75; height * 0.30; # top right
+  width * 0.10; height * 0.70; # bottom left
+  width * 0.50; height * 0.90; # bottom middle
+  width * 0.80; height * 0.70; # bottom right
 _EOF
 )
 
@@ -87,15 +86,8 @@ _EOF
 colors="$(xrdb -query | grep color)"
 
 convert \
-  -size "$size" xc:"$(color 0)" \
-    -stroke white -strokewidth 0 \
-    -fill "$(color 1)" -draw "$(circle 1)" \
-    -fill "$(color 3)" -draw "$(circle 2)" \
-    -fill "$(color 6)" -draw "$(circle 3)" \
-    -fill "$(color 4)" -draw "$(circle 4)" \
-    -fill "$(color 2)" -draw "$(circle 5)" \
-    -resize 10% \
-    -blur 50x200 \
-    -bordercolor "$(color 0)" -border 2x2 \
-    -filter Gaussian -define filter:blur=2 -define filter:sigma=2 -resize 1000% \
+  -size 100x100 xc:  -colorspace RGB \
+    -sparse-color  Voronoi \
+    "$(voronoi_point 1) $(color 1) $(voronoi_point 2) $(color 3) $(voronoi_point 3) $(color 6) $(voronoi_point 4) $(color 4) $(voronoi_point 5) $(color 2)" \
+    -resize "${size}" \
   "$file" && set_wallpaper


### PR DESCRIPTION
The color-wallpaper generation can be dramatically sped up using two tricks.

One is to generate the image much smaller and then resize it. If there were no harsh edges, that would effectively blur the image too thanks to interpolation.

The second trick is to use Voronoi cells based gradient. It produces gradient directly without having to blur overlapping circles and provides more intuitive control of positions and sizes of the colored areas.